### PR TITLE
Support Azure CLI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ providers:
       type: azcli
 ```
 
+When using `azcli` authentication the proxy retrieves a bearer token from the
+Azure CLI credentials (for example acquired via `az login`).
+
 ## Dev environment setup
 
 ```bash

--- a/src/local_llm_proxy/token_providers.py
+++ b/src/local_llm_proxy/token_providers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from typing import cast
+
+from azure.identity.aio import AzureCliCredential
+from azure.core.credentials import AccessToken
+
+
+class TokenProvider(ABC):
+    """Abstract provider interface for acquiring bearer tokens."""
+
+    async def aclose(self) -> None:  # pragma: no cover - default noop
+        """Clean up resources for the provider."""
+        return None
+
+    @abstractmethod
+    async def get_token(self) -> str:
+        """Return a bearer token for authenticating upstream calls."""
+        raise NotImplementedError
+
+
+class ApiKeyProvider(TokenProvider):
+    """Simple token provider that returns a pre-resolved API key."""
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    async def get_token(self) -> str:  # pragma: no cover - trivial
+        return self._api_key
+
+
+class AzCliTokenProvider(TokenProvider):
+    """Token provider that uses Azure CLI credentials."""
+
+    def __init__(self, scope: str = "https://cognitiveservices.azure.com/.default") -> None:
+        self._credential = AzureCliCredential()
+        self._scope = scope
+
+    async def get_token(self) -> str:
+        token = await self._credential.get_token(self._scope)
+        return cast(AccessToken, token).token
+
+    async def aclose(self) -> None:
+        await self._credential.close()

--- a/tests/test_token_provider.py
+++ b/tests/test_token_provider.py
@@ -1,0 +1,15 @@
+from local_llm_proxy.config import AuthConfig, ProviderCfg, RootConfig, build_model_map
+from local_llm_proxy.token_providers import ApiKeyProvider, AzCliTokenProvider
+
+
+def test_build_model_map_creates_providers() -> None:
+    config = RootConfig(
+        providers={
+            "env": ProviderCfg(endpoint="https://example.com", model="m1", auth=AuthConfig(type="apikey", key="abc")),
+            "cli": ProviderCfg(endpoint="https://example.com", model="m2", auth=AuthConfig(type="azcli")),
+        }
+    )
+
+    model_map = build_model_map(config)
+    assert isinstance(model_map["env"].token_provider, ApiKeyProvider)
+    assert isinstance(model_map["cli"].token_provider, AzCliTokenProvider)


### PR DESCRIPTION
## Summary
- implement token provider abstraction
- implement Azure CLI token provider
- load token providers when building model map
- use provider in proxy app
- document azure cli support
- add test for provider map
- fix README indentation

## Testing
- `make check`
- `make test`
- `make build` *(fails: Request failed - No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_6839dc70db948332b3836182b6b6067d