### PR TITLE
Support Azure CLI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ providers:
   azure-o4-mini-azcli:
     endpoint: "https://{service}.cognitiveservices.azure.com/openai/deployments/o4-mini/chat/completions?api-version=2025-01-01-preview"
     model: o4-mini
-    auth:
-      type: azcli
+      auth:
+        type: azcli
 ```
+
+When using `azcli` authentication the proxy retrieves a bearer token from the
+Azure CLI credentials (for example acquired via `az login`).
 
 ## Dev environment setup
 

--- a/src/local_llm_proxy/token_providers.py
+++ b/src/local_llm_proxy/token_providers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from typing import cast
+
+from azure.identity.aio import AzureCliCredential
+from azure.core.credentials import AccessToken
+
+
+class TokenProvider(ABC):
+    """Abstract provider interface for acquiring bearer tokens."""
+
+    async def aclose(self) -> None:  # pragma: no cover - default noop
+        """Clean up resources for the provider."""
+        return None
+
+    @abstractmethod
+    async def get_token(self) -> str:
+        """Return a bearer token for authenticating upstream calls."""
+        raise NotImplementedError
+
+
+class ApiKeyProvider(TokenProvider):
+    """Simple token provider that returns a pre-resolved API key."""
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    async def get_token(self) -> str:  # pragma: no cover - trivial
+        return self._api_key
+
+
+class AzCliTokenProvider(TokenProvider):
+    """Token provider that uses Azure CLI credentials."""
+
+    def __init__(self, scope: str = "https://cognitiveservices.azure.com/.default") -> None:
+        self._credential = AzureCliCredential()
+        self._scope = scope
+
+    async def get_token(self) -> str:
+        token = await self._credential.get_token(self._scope)
+        return cast(AccessToken, token).token
+
+    async def aclose(self) -> None:
+        await self._credential.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+import importlib
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+from pytest_httpx import HTTPXMock
+import yaml
+
+import local_llm_proxy.config as cfg
+
+# These functional tests expect the proxy to accept a mapping of ProviderCfg
+# objects rather than ModelCfg instances. Patch this during each test using the
+# monkeypatch fixture to avoid side effects on other modules.
+
+
+@pytest.fixture()
+def create_config(tmp_path: Path) -> Path:
+    cfg_dir = tmp_path / ".local_llm_proxy"
+    cfg_dir.mkdir()
+    cfg_file = cfg_dir / "config.yaml"
+    cfg_data = {
+        "providers": {
+            "test-model": {
+                "endpoint": "https://mock.upstream/chat/completions",
+                "model": "remote-model",
+                "auth": {
+                    "type": "apikey",
+                    "envKey": "TEST_API_KEY_ENV",
+                },
+            }
+        }
+    }
+    cfg_file.write_text(yaml.dump(cfg_data))
+    return cfg_file
+
+
+class _DummyProvider:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    async def get_token(self) -> str:
+        return self._token
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _build_model_map(config: cfg.RootConfig) -> dict[str, object]:
+    result = {}
+    for name, p in config.providers.items():
+        object.__setattr__(p, "envKey", p.auth.envKey)
+        token = p.auth.api_key or "token"
+        result[name] = types.SimpleNamespace(
+            endpoint=p.endpoint,
+            model=p.model,
+            token_provider=_DummyProvider(token),
+        )
+    return result
+
+
+def test_chat_proxy_success(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
+    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("TEST_API_KEY_ENV", "secret-token")
+
+    proxy_app = importlib.import_module("local_llm_proxy.proxy_app")
+    monkeypatch.setattr(cfg, "ModelCfg", cfg.ProviderCfg)
+    monkeypatch.setattr(proxy_app, "build_model_map", _build_model_map)
+    async def _noop() -> None:
+        return None
+    monkeypatch.setattr(proxy_app, "_shutdown", _noop)
+
+    httpx_mock.add_response(url="https://mock.upstream/chat/completions", json={"ok": True})
+
+    with TestClient(proxy_app.app) as client:
+        resp = client.post(
+            "/test-model/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    req = httpx_mock.get_requests()[0]
+    assert req.headers["Authorization"] == "Bearer secret-token"
+
+
+def test_chat_proxy_upstream_error(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
+    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("TEST_API_KEY_ENV", "token")
+
+    proxy_app = importlib.import_module("local_llm_proxy.proxy_app")
+    monkeypatch.setattr(cfg, "ModelCfg", cfg.ProviderCfg)
+    monkeypatch.setattr(proxy_app, "build_model_map", _build_model_map)
+    async def _noop() -> None:
+        return None
+    monkeypatch.setattr(proxy_app, "_shutdown", _noop)
+
+    import httpx
+
+    httpx_mock.add_exception(httpx.ConnectError("boom"))
+
+    with TestClient(proxy_app.app) as client:
+        resp = client.post(
+            "/test-model/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 502
+        assert resp.json() == {"error": "Upstream failure"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,81 @@
-import pytest
 from pathlib import Path
 
-from local_llm_proxy.config import load_config
+import pytest
+from pydantic import ValidationError
+
+from local_llm_proxy.config import load_config, parse_config
 
 
 def test_load_config_file_not_found(tmp_path: Path) -> None:
     """Test FileNotFoundError when config file does not exist."""
     with pytest.raises(FileNotFoundError):
         load_config(tmp_path / "non_existent.yaml")
+
+
+def test_parse_config_valid_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid config resolves an API key from the environment."""
+    monkeypatch.setenv("TEST_ENV_KEY", "abc123")
+    raw = {
+        "providers": {
+            "p1": {
+                "endpoint": "https://example.com",
+                "model": "m",
+                "auth": {"type": "apikey", "envKey": "TEST_ENV_KEY"},
+            }
+        }
+    }
+    cfg = parse_config(raw)
+    assert cfg.providers["p1"].auth.api_key == "abc123"
+
+
+def test_parse_config_missing_default_provider() -> None:
+    """Defaults referencing unknown providers should fail validation."""
+    raw = {
+        "defaults": {"provider": "missing"},
+        "providers": {
+            "p1": {
+                "endpoint": "https://example.com",
+                "model": "m",
+                "auth": {"type": "apikey", "key": "k"},
+            }
+        },
+    }
+    with pytest.raises(ValidationError):
+        parse_config(raw)
+
+
+def test_parse_config_providers_empty() -> None:
+    """Configuration must contain at least one provider."""
+    with pytest.raises(ValidationError):
+        parse_config({"providers": {}})
+
+
+def test_parse_config_apikey_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An apikey auth entry without key or envKey should fail."""
+    monkeypatch.delenv("MISSING", raising=False)
+    raw = {
+        "providers": {
+            "p1": {
+                "endpoint": "https://example.com",
+                "model": "m",
+                "auth": {"type": "apikey", "envKey": "MISSING"},
+            }
+        }
+    }
+    with pytest.raises(ValidationError):
+        parse_config(raw)
+
+
+def test_parse_config_azcli_returns_none() -> None:
+    """Auth of type azcli should not resolve an API key."""
+    raw = {
+        "providers": {
+            "p1": {
+                "endpoint": "https://example.com",
+                "model": "m",
+                "auth": {"type": "azcli"},
+            }
+        }
+    }
+    cfg = parse_config(raw)
+    assert cfg.providers["p1"].auth.api_key is None

--- a/tests/test_token_provider.py
+++ b/tests/test_token_provider.py
@@ -1,0 +1,15 @@
+from local_llm_proxy.config import AuthConfig, ProviderCfg, RootConfig, build_model_map
+from local_llm_proxy.token_providers import ApiKeyProvider, AzCliTokenProvider
+
+
+def test_build_model_map_creates_providers() -> None:
+    config = RootConfig(
+        providers={
+            "env": ProviderCfg(endpoint="https://example.com", model="m1", auth=AuthConfig(type="apikey", key="abc")),
+            "cli": ProviderCfg(endpoint="https://example.com", model="m2", auth=AuthConfig(type="azcli")),
+        }
+    )
+
+    model_map = build_model_map(config)
+    assert isinstance(model_map["env"].token_provider, ApiKeyProvider)
+    assert isinstance(model_map["cli"].token_provider, AzCliTokenProvider)


### PR DESCRIPTION
## Summary
- implement token provider abstraction
- implement Azure CLI token provider
- load token providers when building model map
- use provider in proxy app
- document azure cli support
- add test for provider map
- fix tests after merging main

## Testing
- `make check`
- `make test`
- `make build` *(fails: Request failed - No route to host)*


------
https://chatgpt.com/codex/tasks/task_e_6839dc70db948332b3836182b6b6067d