### PR TITLE
Add Azure CLI auth provider

### DIFF
--- a/src/local_llm_proxy/auth_providers.py
+++ b/src/local_llm_proxy/auth_providers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from azure.identity import AzureCliCredential
+from azure.core.credentials import AccessToken
+
+
+class TokenProvider(ABC):
+    """Abstract base class for retrieving bearer tokens."""
+
+    @abstractmethod
+    def get_token(self) -> str:
+        """Return a bearer token string."""
+        raise NotImplementedError
+
+
+class ApiKeyProvider(TokenProvider):
+    """Simple provider that returns a static API key."""
+
+    def __init__(self, key: str):
+        self._key = key
+
+    def get_token(self) -> str:  # noqa: D401 - simple return
+        """Return the stored API key."""
+        return self._key
+
+
+class AzureCliProvider(TokenProvider):
+    """Provider that fetches a token from Azure CLI credentials."""
+
+    _SCOPE = "https://cognitiveservices.azure.com/.default"
+
+    def __init__(self) -> None:
+        self._credential = AzureCliCredential()
+
+    def get_token(self) -> str:
+        access_token: AccessToken = self._credential.get_token(self._SCOPE)
+        return access_token.token

--- a/src/local_llm_proxy/forwarder.py
+++ b/src/local_llm_proxy/forwarder.py
@@ -6,7 +6,7 @@ from typing import Mapping
 
 import httpx
 
-from .config import ModelCfg
+from .config import ProviderCfg
 
 
 class Forwarder:
@@ -14,7 +14,7 @@ class Forwarder:
 
     _TIMEOUT = httpx.Timeout(600.0)  # 10 minutes
 
-    def __init__(self, model_map: Mapping[str, ModelCfg]):
+    def __init__(self, model_map: Mapping[str, ProviderCfg]):
         self._model_map = model_map
         self._client = httpx.AsyncClient(timeout=self._TIMEOUT)
 


### PR DESCRIPTION
## Summary
- add token provider abstractions
- support Azure CLI auth
- wire proxy to use the new provider
- update tests for new auth behaviour

## Testing
- `make check`
- `make test`
- `make build` *(fails: Failed to fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6839f7511fe88332b5ddbd0ec4ee97b5