### PR TITLE
Fix failing tests due to incorrect endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,7 +56,7 @@ def test_chat_proxy_success(monkeypatch: pytest.MonkeyPatch, create_config: Path
 
     with TestClient(proxy_app.app) as client:
         resp = client.post(
-            "/test-model/chat/completions",
+            "/provider/test-model/chat/completions",
             json={"messages": [{"role": "user", "content": "hi"}]},
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- fix request path in API test

## Testing
- `make check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683b3aee258c833294e2a74534dd8aab